### PR TITLE
Allow to use ADC channels above 15

### DIFF
--- a/source/analogin_api.c
+++ b/source/analogin_api.c
@@ -66,7 +66,7 @@ uint16_t analogin_read_u16(analogin_t *obj) {
     uint32_t instance = obj->adc >> ADC_INSTANCE_SHIFT;
     uint32_t adc_addrs[] = ADC_BASE_ADDRS;
     /* sw trigger (SC1A) */
-    ADC_HAL_ConfigChn(adc_addrs[instance], 0, false, false, obj->adc & 0xF);
+    ADC_HAL_ConfigChn(adc_addrs[instance], 0, false, false, obj->adc & 0x1F);
     while (!ADC_HAL_GetChnConvCompletedCmd(adc_addrs[instance], 0));
     return ADC_HAL_GetChnConvValueRAW(adc_addrs[instance], 0);
 }


### PR DESCRIPTION
On Freedom K64F, ADC channels go up to number 18
The 0xF mask prevents using them
See https://github.com/ARMmbed/mbed-hal-frdm-k64f/blob/master/mbed-hal-frdm-k64f/PeripheralNames.h
